### PR TITLE
Remove flutter dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,13 +5,11 @@ homepage: https://github.com/Enough-Software/enough_icalendar
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.17.0"
 
 dependencies:
   collection: ^1.15.0
   intl: ^0.17.0
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
   lints: ^1.0.1
+  test: ^1.20.2

--- a/test/components_test.dart
+++ b/test/components_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:enough_icalendar/enough_icalendar.dart';
 
 void main() {

--- a/test/duration_test.dart
+++ b/test/duration_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:enough_icalendar/enough_icalendar.dart';
 
 void main() {

--- a/test/extension_test.dart
+++ b/test/extension_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:enough_icalendar/enough_icalendar.dart';
 
 void main() {

--- a/test/itip_examples_test.dart
+++ b/test/itip_examples_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:enough_icalendar/enough_icalendar.dart';
 
 // examples taken from https://datatracker.ietf.org/doc/html/rfc5546#section-4

--- a/test/itip_test.dart
+++ b/test/itip_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:enough_icalendar/enough_icalendar.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 

--- a/test/properties_test.dart
+++ b/test/properties_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:enough_icalendar/enough_icalendar.dart';
 
 void main() {

--- a/test/rrule_test.dart
+++ b/test/rrule_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 import 'package:enough_icalendar/enough_icalendar.dart';
 
 void main() {


### PR DESCRIPTION
Hello:), this library does not need anything from Flutter, so there is no need to depend on Flutter in `pubspec.yaml`. Without the dependency, it can be used in standalone Dart (like on a server for example).